### PR TITLE
Support full GitHub URLs in GitHubClient

### DIFF
--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitHubClient.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitHubClient.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.gitsemver
 
@@ -54,7 +54,13 @@ public class GitHubClient {
             .build()
         MediaType mediaType = MediaType.parse("application/vnd.github+json")
         //TODO allow full URL
-        
+        if (repo.startsWith("http")) {
+            def matcher = repo =~ /https?:\/\/[^\/]+\/([^\/]+\/[^\/]+?)(?:\.git)?$/
+            if (matcher) {
+                repo = matcher[0][1]
+            }
+        }
+
         def url = "https://api.github.com/repos/${repo}/releases/latest"
         if(version != "latest") {
             url = "https://api.github.com/repos/${repo}/releases/tags/${version}"

--- a/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverInstallationSpec.groovy
+++ b/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverInstallationSpec.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.gitsemver
 
@@ -43,6 +43,7 @@ public class GitSemverInstallationSpec extends ProjectSpec {
         where:
         repoName              | osType          | archType      | version  | ghVersion
         "PSanetra/git-semver" | OS.Family.LINUX | OS.Arch.AMD64 | "latest" | "v1.1.1"
+        "https://github.com/PSanetra/git-semver" | OS.Family.LINUX | OS.Arch.AMD64 | "latest" | "v1.1.1"
     }
 
 


### PR DESCRIPTION
Updated `GitHubClient.groovy` to parse full URLs in the `repo` parameter, extracting the `owner/repo` path. This change supports both the existing `owner/repo` format and full HTTP/HTTPS URLs. Verified with a new test case in `GitSemverInstallationSpec`.

---
*PR created automatically by Jules for task [6300863817414909622](https://jules.google.com/task/6300863817414909622) started by @boxheed*