### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverCurrentVersionTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverCurrentVersionTask.groovy
@@ -7,7 +7,9 @@ import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
+@UntrackedTask(because = "This task requires git-semver execution output")
 public class GitSemverCurrentVersionTask extends DefaultTask {
 
     public static final String NAME = "semver"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverInstallAllTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverInstallAllTask.groovy
@@ -6,8 +6,9 @@ import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
-
+@UntrackedTask(because = "This task requires git-semver execution output")
 public class GitSemverInstallAllTask extends DefaultTask {
 
     public static final String NAME = "installAllSemvers"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverInstallTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverInstallTask.groovy
@@ -9,7 +9,9 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional as OptionalTask
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
+@UntrackedTask(because = "This task requires git-semver execution output")
 public abstract class GitSemverInstallTask extends DefaultTask {
 
     public static final String NAME = "installSemver"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverNextVersionTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverNextVersionTask.groovy
@@ -7,7 +7,9 @@ import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
+@UntrackedTask(because = "This task requires git-semver execution output")
 public class GitSemverNextVersionTask extends DefaultTask {
 
     public static final String NAME = "nextSemver"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverStatusTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverStatusTask.groovy
@@ -6,8 +6,10 @@ import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.process.ExecOperations
 
+@UntrackedTask(because = "This task requires git-semver execution output")
 public class GitSemverStatusTask extends DefaultTask {
 
     public static final String NAME = "gitStatus"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverTagTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/gitsemver/GitSemverTagTask.groovy
@@ -6,7 +6,9 @@ import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 
+@UntrackedTask(because = "This task requires git-semver execution output")
 public class GitSemverTagTask extends DefaultTask {
 
     public static final String NAME = "tagSemver"


### PR DESCRIPTION
This commit resolves a task validation failure introduced by upgrading the Gradle Wrapper to 9.4.0. Gradle 9+ strictly enforces caching annotations for tasks. Tasks relying on external state, such as `git-semver` command execution, must be explicitly marked. Added the `@UntrackedTask` annotation to all corresponding task classes to satisfy plugin validation rules.

---
*PR created automatically by Jules for task [13967217165402859609](https://jules.google.com/task/13967217165402859609) started by @boxheed*